### PR TITLE
ARS-291 update bni csv parser

### DIFF
--- a/bni.go
+++ b/bni.go
@@ -12,7 +12,7 @@ const (
 	BniIndexNumberAmount         = 6
 )
 
-var BniBlacklist = []string{"DARI", "TRANSFER", "Sdr", "|", "PEMINDAHAN"}
+var BniBlacklist = []string{"DARI", "TRANSFER", "Sdr", "Sdri", "|", "PEMINDAHAN"}
 
 type bniParser struct {
 	record        []string
@@ -31,7 +31,7 @@ func (p *bniParser) parseRecord() error {
 	d := p.record[BniIndexNumberDescription]
 	p.description = d
 	p.accountName = p.parseAccountName(d)
-	p.accountNumber = p.parseAccountNumber(d)
+	// p.accountNumber = p.parseAccountNumber(d) // new bni csv doesn't include bank account number
 	p.amount = p.record[BniIndexNumberAmount]
 	date := p.record[BniIndexNumberValidationDate]
 	p.date = p.parseDate(date)
@@ -46,6 +46,7 @@ func (p *bniParser) parseAccountName(s string) string {
 	an := make([]string, 0)
 
 	for _, v := range ns {
+		v = strings.ReplaceAll(v, "|", "")
 		if !p.isAllNumber(v) {
 			an = append(an, v)
 		}

--- a/bni_test.go
+++ b/bni_test.go
@@ -15,7 +15,7 @@ type BniMutationTestSuite struct {
 }
 
 func (suite *BniMutationTestSuite) SetupTest() {
-	suite.BniMutationRec = []string{"02/12/19 06.25.21", "02/12/19 06.25.21", "0996", "932902", "TRANSFER DARI | PEMINDAHAN DARI 719147165 Sdr JOHN DOE", ".00", "200,000.00"}
+	suite.BniMutationRec = []string{"04/05/20 12.28.07", "04/05/20 12.28.07", "0989", "359823", "TRANSFER DARI | |7878078081 20200504945299342 | Sdr EKA DANA KRISTANTO   ", ".00", "250,000.00"}
 	suite.InvalidBniMutationRec = []string{"test", "invalid", "record"}
 	suite.parser = NewBniParser()
 }
@@ -35,23 +35,24 @@ func (suite *BniMutationTestSuite) TestGetAccountName() {
 	v := suite.parser.GetAccountName()
 
 	assert.Nil(suite.T(), err, "Error should be nil")
-	assert.Equal(suite.T(), "JOHN DOE", v, "Account name is empty")
+	assert.Equal(suite.T(), "EKA DANA KRISTANTO", v, "Account name is empty")
 }
 
-func (suite *BniMutationTestSuite) TestGetAccountNumber() {
-	err := suite.parser.LoadRecord(suite.BniMutationRec)
-	v := suite.parser.GetAccountNumber()
+// New BNI CSV doesn't include bank account number
+// func (suite *BniMutationTestSuite) TestGetAccountNumber() {
+// 	err := suite.parser.LoadRecord(suite.BniMutationRec)
+// 	v := suite.parser.GetAccountNumber()
 
-	assert.Nil(suite.T(), err, "Error should be nil")
-	assert.Equal(suite.T(), "719147165", v, "Account number is empty")
-}
+// 	assert.Nil(suite.T(), err, "Error should be nil")
+// 	assert.Equal(suite.T(), "719147165", v, "Account number is empty")
+// }
 
 func (suite *BniMutationTestSuite) TestGetAmount() {
 	err := suite.parser.LoadRecord(suite.BniMutationRec)
 	v := suite.parser.GetAmount()
 
 	assert.Nil(suite.T(), err, "Error should be nil")
-	assert.Equal(suite.T(), "200000", v, "Amount is wrong")
+	assert.Equal(suite.T(), "250000", v, "Amount is wrong")
 }
 
 func (suite *BniMutationTestSuite) TestGetDescription() {
@@ -59,7 +60,7 @@ func (suite *BniMutationTestSuite) TestGetDescription() {
 	v := suite.parser.GetDescription()
 
 	assert.Nil(suite.T(), err, "Error should be nil")
-	assert.Equal(suite.T(), "TRANSFER DARI | PEMINDAHAN DARI 719147165 Sdr JOHN DOE", v, "Description is wrong")
+	assert.Equal(suite.T(), "TRANSFER DARI | |7878078081 20200504945299342 | Sdr EKA DANA KRISTANTO   ", v, "Description is wrong")
 }
 
 func (suite *BniMutationTestSuite) TestGetDate() {
@@ -67,7 +68,7 @@ func (suite *BniMutationTestSuite) TestGetDate() {
 	v := suite.parser.GetDate()
 
 	assert.Nil(suite.T(), err, "Error should be nil")
-	assert.Equal(suite.T(), "02/12/19", v, "Date is wrong")
+	assert.Equal(suite.T(), "04/05/20", v, "Date is wrong")
 }
 
 func TestBniMutationTestSuite(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?
Update BNI parser to read this BNI csv format:

> 04/05/20 12.28.07,04/05/20 12.28.07,0989,359823,"TRANSFER DARI | |7878078081 20200504945299342 | Sdr EKA DANA KRISTANTO   ",".00","250,000.00",

Note:
- bank account number is remove from BNI csv. No need to retrieve bank account number, so do the unit test.

## Why are we doing this? Any context or related work?
https://kitabisa.atlassian.net/browse/ARS-291
