### PR TITLE
ARS-320 enable parse hundreds amount

### DIFF
--- a/bni_test.go
+++ b/bni_test.go
@@ -15,7 +15,7 @@ type BniMutationTestSuite struct {
 }
 
 func (suite *BniMutationTestSuite) SetupTest() {
-	suite.BniMutationRec = []string{"04/05/20 12.28.07", "04/05/20 12.28.07", "0989", "359823", "TRANSFER DARI | |7878078081 20200504945299342 | Sdr EKA DANA KRISTANTO   ", ".00", "250,000.00"}
+	suite.BniMutationRec = []string{"04/05/20 12.28.07", "04/05/20 12.28.07", "0989", "359823", "TRANSFER DARI | PEMINDAHAN DARI 390397011 Sdr EKA DANA KRISTANTO | 7878078081 20200504945299342 | |", ".00", "250,500.00"}
 	suite.InvalidBniMutationRec = []string{"test", "invalid", "record"}
 	suite.parser = NewBniParser()
 }
@@ -52,7 +52,7 @@ func (suite *BniMutationTestSuite) TestGetAmount() {
 	v := suite.parser.GetAmount()
 
 	assert.Nil(suite.T(), err, "Error should be nil")
-	assert.Equal(suite.T(), "250000", v, "Amount is wrong")
+	assert.Equal(suite.T(), "250500", v, "Amount is wrong")
 }
 
 func (suite *BniMutationTestSuite) TestGetDescription() {
@@ -60,7 +60,7 @@ func (suite *BniMutationTestSuite) TestGetDescription() {
 	v := suite.parser.GetDescription()
 
 	assert.Nil(suite.T(), err, "Error should be nil")
-	assert.Equal(suite.T(), "TRANSFER DARI | |7878078081 20200504945299342 | Sdr EKA DANA KRISTANTO   ", v, "Description is wrong")
+	assert.Equal(suite.T(), "TRANSFER DARI | PEMINDAHAN DARI 390397011 Sdr EKA DANA KRISTANTO | 7878078081 20200504945299342 | |", v, "Description is wrong")
 }
 
 func (suite *BniMutationTestSuite) TestGetDate() {

--- a/trimmer.go
+++ b/trimmer.go
@@ -33,7 +33,7 @@ func BlacklistTrim(ar, blacklist []string) []string {
 }
 
 func NumericTrim(s string) (string, error) {
-	s = strings.Replace(s, ",00", "", -1)
+	s = strings.Replace(s, ".00", "", -1)
 	reg, err := regexp.Compile("[^0-9]+")
 	if err != nil {
 		return "", err

--- a/trimmer_test.go
+++ b/trimmer_test.go
@@ -22,9 +22,25 @@ func TestBlacklistTrim(t *testing.T) {
 }
 
 func TestNumericTrim(t *testing.T) {
-	s := "100.000"
+	s := "100,000.00"
 	v, err := NumericTrim(s)
 
 	assert.Nil(t, err, "Error should be nil")
 	assert.Equal(t, "100000", v, "Numeric value is wrong")
+}
+
+func TestNumericHundreds(t *testing.T) {
+	s := "100,300.00"
+	v, err := NumericTrim(s)
+
+	assert.Nil(t, err, "Error should be nil")
+	assert.Equal(t, "100300", v, "Numeric value is wrong")
+}
+
+func TestNumericDozens(t *testing.T) {
+	s := "100,370.00"
+	v, err := NumericTrim(s)
+
+	assert.Nil(t, err, "Error should be nil")
+	assert.Equal(t, "100370", v, "Numeric value is wrong")
 }


### PR DESCRIPTION
## What does this PR do?
enable parse hundreds amount

## Why are we doing this? Any context or related work?
based on slack report:
> barusan dapat laporan dari tim operation kalo ada csv user yg amountnya 387.500, tapi gagal parsing. pas nge-read bca csv kebaca 38.750.000. rupanya ada bug di moco yg salah read kalo nominal user pake pecahan ratusan. takutnya ngefek ke bank yg lain juga.

https://kitabisa.atlassian.net/browse/ARS-320

## Manual testing steps?
run unit test. all should pass.
